### PR TITLE
Fixed multiparameter methods call generation

### DIFF
--- a/jnim.nim
+++ b/jnim.nim
@@ -768,6 +768,7 @@ proc generateJNIProc(e: NimNode): NimNode {.compileTime.} =
             argsSigNode.add(newCall("methodSignatureForType", result.params[i][^2]))
             initParamsNode.add quote do:
                 toJValue(`p`, `paramsSym`[`iParam`])
+            inc iParam
 
     let setterType = newCall("type", if numArgs > 0:
             result.params[2][0]


### PR DESCRIPTION
There was a problem with parameters array generation. Here is the generated code example:

``` nim
proc setProperty(p: Properties; k: string; v: string): Object =
  var params {.noinit.}: array[2, jvalue]
  toJValue(k, params[0])
  toJValue(v, params[0])
  jniImpl("setProperty", false, false, p, concatStrings(
      methodSignatureForType(string), methodSignatureForType(string)), params,
          type(k))
```

See `params` array in `toJValue` call, it uses zero index forever. This PR fixes it.
