### PR TITLE
Extend import syntax

### DIFF
--- a/test/TestSyntax.java
+++ b/test/TestSyntax.java
@@ -1,0 +1,7 @@
+public class TestSyntax {
+
+    public String say() {
+        return "Hello from TestSyntax";
+    }
+    
+}

--- a/test/private/jmodule.nim
+++ b/test/private/jmodule.nim
@@ -1,0 +1,15 @@
+import "../../jnim"
+
+jnimportEx:
+  import TestSyntax
+  import TestSyntax as JTestSyntax
+  
+  import java.lang.String as JString
+
+  proc `$`(o: JString): string {.importc: "toString".}
+
+  proc new(s: typedesc[TestSyntax])
+  proc say(o: TestSyntax): string
+
+  proc new(s: typedesc[JTestSyntax])
+  proc jsay(o: JTestSyntax): JString {.importc: "say".}

--- a/test/test_syntax.nim
+++ b/test/test_syntax.nim
@@ -1,0 +1,33 @@
+import "../jnim", unittest
+
+let jvm = newJavaVM()
+
+jnimport:
+  import TestSyntax
+  import TestSyntax as JTestSyntax
+  
+  import java.lang.String as JString
+
+  proc `$`(o: JString): string {.importc: "toString".}
+
+  proc new(s: typedesc[TestSyntax])
+  proc say(o: TestSyntax): string
+
+  proc new(s: typedesc[JTestSyntax])
+  proc jsay(o: JTestSyntax): JString {.importc: "say".}
+
+suite "Syntax":
+  test "Syntax - Import class":
+    # Check if class is declared
+    check: declared(TestSyntax)
+
+  test "Syntax - Import method":
+    let o = TestSyntax.new
+    check: o.say == "Hello from TestSyntax"
+
+  test "Syntax - Import class with qualified name":
+    check: declared(JTestSyntax)
+    
+  test "Syntax - Import method with qualified name":
+    let o = JTestSyntax.new
+    check: o.jsay.`$` == "Hello from TestSyntax"

--- a/test/test_syntax.nim
+++ b/test/test_syntax.nim
@@ -2,7 +2,7 @@ import "../jnim", unittest
 
 let jvm = newJavaVM()
 
-jnimport:
+jnimportEx:
   import TestSyntax
   import TestSyntax as JTestSyntax
   
@@ -18,7 +18,6 @@ jnimport:
 
 suite "Syntax":
   test "Syntax - Import class":
-    # Check if class is declared
     check: declared(TestSyntax)
 
   test "Syntax - Import method":

--- a/test/test_syntax.nim
+++ b/test/test_syntax.nim
@@ -1,20 +1,6 @@
-import "../jnim", unittest
+import "../jnim", private.jmodule, unittest
 
 let jvm = newJavaVM()
-
-jnimportEx:
-  import TestSyntax
-  import TestSyntax as JTestSyntax
-  
-  import java.lang.String as JString
-
-  proc `$`(o: JString): string {.importc: "toString".}
-
-  proc new(s: typedesc[TestSyntax])
-  proc say(o: TestSyntax): string
-
-  proc new(s: typedesc[JTestSyntax])
-  proc jsay(o: JTestSyntax): JString {.importc: "say".}
 
 suite "Syntax":
   test "Syntax - Import class":


### PR DESCRIPTION
##### Rename imported classes and methods:

``` nim
jnimport:
  import java.lang.Object as JObject

  proc `$`(o: JObject): string {.importc: toString.}
```
##### Export imported java classes and methods from the nim module:

``` nim
jnimportEx:
  import java.lang.Object as JObject

  proc `$`(o: JObject): string {.importc: toString.}
```
