### PR TITLE
Add instanceOf and jcast procs to core

### DIFF
--- a/src/javaapi/core.nim
+++ b/src/javaapi/core.nim
@@ -1,4 +1,5 @@
 import jnim
+from typetraits import name
 
 # Forward declarations
 jclassDef java.lang.Object* of JVMObject
@@ -155,3 +156,50 @@ proc asJVM*(ex: JavaException): Throwable =
 
 proc getCurrentJVMException*: Throwable =
   ((ref JavaException)getCurrentException())[].asJVM
+
+
+#################################################################################################### 
+# Operators
+
+
+proc instanceOf*[T: JVMObject](obj: JVMObject, t: typedesc[T]): bool =
+  ## Returns true if java object `obj` is an instance of class, represented
+  ## by `T`. Behaves the same as `instanceof` operator in Java.
+  ## **WARNING**: since generic parameters are not represented on JVM level,
+  ## they are ignored (even though they are required by Nim syntax). This
+  ## means that the following returns true:
+  ## .. code-block:: nim
+  ##   let a = ArrayList[Integer].new()
+  ##   # true!
+  ##   a.instanceOf[List[String]]
+
+  instanceOfRaw(obj, T.getJVMClassForType)
+
+proc jcast*[T: JVMObject](obj: JVMObject): T =
+  ## Downcast operator for Java objects.
+  ## Behaves like Java code `(T) obj`. That is:
+  ## - If java object, referenced by `obj`, is an instance of class,
+  ## represented by `T` - returns an object of `T` that references
+  ## the same java object.
+  ## - Otherwise raises an exception (`ObjectConversionError`).
+  ## **WARNING**: since generic parameters are not represented on JVM level,
+  ## they are ignored (even though they are required by Nim syntax). This
+  ## means that the following won't raise an error:
+  ## .. code-block:: nim
+  ##   let a = ArrayList[Integer].new()
+  ##   # no error here!
+  ##   let b = jcast[List[String]](a)
+  ## **WARNING**: To simplify reference handling, this implementation directly
+  ## casts JVMObject to a subtype. This works, since all mapped classes have
+  ## the same structure, but also breaks Nim's runtime type determination
+  ## (such as `of` keyword and methods). However, native runtime type
+  ## determination should not be used with mapped classes anyway.
+
+  if not obj.instanceOf(T):
+    raise newException(
+      ObjectConversionError,
+      "Failed to convert " & obj.type.name &
+        " to " & typetraits.name(T)
+    )
+  # Since it is just a ref
+  cast[T](obj)

--- a/src/private/jni_api.nim
+++ b/src/private/jni_api.nim
@@ -680,3 +680,7 @@ template callMethod*(T: typedesc, o: expr, methodId: JVMMethodID, args: openarra
     T.fromJObject(o.callObjectMethodRaw(methodId, args))
   else:
     {.error: "Unknown return type".}
+
+proc instanceOfRaw*(obj: JVMObject, cls: JVMClass): bool =
+  checkInit
+  callVM theEnv.IsInstanceOf(theEnv, obj.obj, cls.cls) == JVM_TRUE

--- a/src/private/jni_wrapper.nim
+++ b/src/private/jni_wrapper.nim
@@ -260,6 +260,7 @@ type
     SetLongArrayRegion*: proc(env: JNIEnvPtr, arr: jlongArray, start, len: jsize, buf: ptr jlong) {.cdecl.}
     SetFloatArrayRegion*: proc(env: JNIEnvPtr, arr: jfloatArray, start, len: jsize, buf: ptr jfloat) {.cdecl.}
     SetDoubleArrayRegion*: proc(env: JNIEnvPtr, arr: jdoubleArray, start, len: jsize, buf: ptr jdouble) {.cdecl.}
+    IsInstanceOf*: proc(env: JNIEnvPtr, obj: jobject, clazz: jclass): jboolean {.cdecl.}
 
   JNIEnv* = ptr JNINativeInterface
   JNIEnvPtr* = ptr JNIEnv

--- a/tests/test_javaapi_core.nim
+++ b/tests/test_javaapi_core.nim
@@ -51,3 +51,24 @@ suite "javaapi.core":
     check: Short.MAX_VALUE == high(int16)
 
     check: Integer.new(1) == Integer.new(1)
+
+  test "javaapi.core - instanceOf":
+    let
+      i = newJVMObject(Integer.new(1).get)
+      s = newJVMObject(String.new("foo").get)
+
+    check: i.instanceOf(Integer)
+    check: i.instanceOf(Object)
+    check: s.instanceOf(String)
+    check: s.instanceOf(Object)
+    check: not i.instanceOf(String)
+    check: not s.instanceOf(Integer)
+
+  test "javaapi.core - jcast":
+    let
+      s = newJVMObject(String.new("foo").get)
+
+    check: jcast[String](s) is String
+    check: jcast[Object](s) is Object
+    expect ObjectConversionError:
+      discard jcast[Integer](s)


### PR DESCRIPTION
Add two procs to facilitate casting in runtime:
- `instanceOf` (a version of `instanceof` operator in Java)
- `jcast` (checked downcast)
