### PR TITLE
Fixed compile errors. Fixed JAVA_HOME search on macos.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   # Install nim
   - git clone -b devel git://github.com/nim-lang/Nim.git --depth 1
   - cd Nim
-  - git clone -b devel --depth 1 git://github.com/nim-lang/csources
+  - git clone --depth 1 git://github.com/nim-lang/csources
   - cd csources && sh build.sh
   - cd ..
   - bin/nim c koch

--- a/src/private/jni_api.nim
+++ b/src/private/jni_api.nim
@@ -24,7 +24,7 @@ proc initJNIThread* {.gcsafe.}
 proc initJNI*(version: JNIVersion = JNIVersion.v1_6, options: seq[string] = @[]) =
   ## Setup JNI API
   jniAssert(not theOptions.isDefined, "JNI API already initialized, you must deinitialize it first")
-  theOptions = (version, options).some
+  theOptions = (version: version, options: options).some
   theOptionsPtr = cast[pointer](theOptions)
   initJNIThread()
 


### PR DESCRIPTION
1. There is a couple of errors after Nim 0.15 released. Specifically this change from nim release notes:
```
The compiler is now more picky when it comes to tuple types. The following code used to compile, now it's rejected:
```

2. I don't have any libjvm on MacOS Sierra, and the lib is not used in macos impl of jnim anyway, so there's a fix for that. Struggled to keep it in your fancy fp style ;)