### PR TITLE
Experimental export support

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -48,6 +48,8 @@ proc javac(file: string, outDir: string) =
 
 task int_test_bootstrap, "Prepare test environment":
   BUILD_DIR.mkDir
+  javac "support/io/github/vegansk/jnim/NativeInvocationHandler.java", BUILD_DIR
+
   javac "tests/java/TestClass.java", BUILD_DIR
   javac "tests/java/ConstructorTestClass.java", BUILD_DIR
   javac "tests/java/MethodTestClass.java", BUILD_DIR
@@ -57,6 +59,7 @@ task int_test_bootstrap, "Prepare test environment":
   javac "tests/java/GenericsTestClass.java", BUILD_DIR
   javac "tests/java/BaseClass.java", BUILD_DIR
   javac "tests/java/ChildClass.java", BUILD_DIR
+  javac "tests/java/ExportTestClass.java", BUILD_DIR
 
 task test, "Run all tests":
   dep int_test_bootstrap
@@ -77,6 +80,10 @@ task test_jni_api, "Run jni_api test":
 task test_jni_generator, "Run jni_api test":
   dep int_test_bootstrap
   test "jni_generator"
+
+task test_jni_export, "Run jni_export test":
+  dep int_test_bootstrap
+  test "jni_export"
 
 task test_java_lang, "Run java.lang test":
   dep int_test_bootstrap

--- a/src/private/jni_export.nim
+++ b/src/private/jni_export.nim
@@ -1,0 +1,136 @@
+import macros
+
+import jni_wrapper, jni_api, jni_generator
+import java.lang except Exception
+
+type ProxyFunc = proc(env: pointer, obj: RootRef, proxiedThis, meth: jobject, args: jobjectArray): jobject {.cdecl.}
+
+jclass java.lang.reflect.Method of JVMObject:
+    proc getName(): string
+
+proc rawHandleInvocation(env: pointer, clazz: jclass, nimRef, fnPtr: jlong, proxiedThis, meth: jobject, args: jobjectArray): jobject {.cdecl.} =
+    let o = cast[RootRef](nimRef)
+    let f = cast[ProxyFunc](fnPtr)
+    f(env, o, proxiedThis, meth, args)
+
+proc finalizeInvocationHandler(env: pointer, clazz: jclass, nimRef: jlong) {.cdecl.} =
+    echo "finalizer!"
+    if nimRef != 0:
+        let o = cast[RootRef](nimRef)
+        GC_unref(o)
+
+proc getHandlerClass(): jclass =
+    checkInit
+    result = theEnv.FindClass(theEnv, "io/github/vegansk/jnim/NativeInvocationHandler")
+    if result.pointer.isNil:
+        theEnv.ExceptionClear(theEnv)
+        result = theEnv.FindClass(theEnv, "NativeInvocationHandler")
+        if result.pointer.isNil:
+            theEnv.ExceptionClear(theEnv)
+            raise newException(Exception, "invalid jnim integration, NativeInvocationHandler not found")
+
+    var nativeMethods: array[2, JNINativeMethod]
+    nativeMethods[0].name = "i"
+    nativeMethods[0].signature = "(JJLjava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;"
+    nativeMethods[0].fnPtr = cast[pointer](rawHandleInvocation)
+    nativeMethods[1].name = "f"
+    nativeMethods[1].signature = "(J)V"
+    nativeMethods[1].fnPtr = cast[pointer](finalizeInvocationHandler)
+
+    let r = callVM theEnv.RegisterNatives(theEnv, result, addr nativeMethods[0], nativeMethods.len.jint)
+    assert(r == 0)
+
+proc makeProxy*(clazz: jclass, o: RootRef, fn: ProxyFunc): jobject =
+    let handlerClazz = getHandlerClass()
+
+    GC_ref(o)
+
+    var mkArgs: array[3, jvalue]
+    mkArgs[0].l = cast[jobject](clazz)
+    mkArgs[1].j = cast[jlong](o)
+    mkArgs[2].j = cast[jlong](fn)
+
+    let mkId = callVM theEnv.GetStaticMethodID(theEnv, handlerClazz, "m", "(Ljava/lang/Class;JJ)Ljava/lang/Object;")
+    assert(mkId != nil)
+
+    result = callVM theEnv.CallStaticObjectMethodA(theEnv, handlerClazz, mkId, addr mkArgs[0])
+    assert(result != nil)
+    theEnv.DeleteLocalRef(theEnv, cast[jobject](handlerClazz))
+
+template makeProxy*[T](javaInterface: typedesc, o: ref T, fn: proc(env: pointer, obj: ref T, proxiedThis, meth: jobject, args: jobjectArray): jobject {.cdecl.}): untyped =
+    let clazz = javaInterface.getJVMClassForType()
+    javaInterface.fromJObject(makeProxy(clazz.get(), cast[RootRef](o), cast[ProxyFunc](fn)))
+
+################################################################################
+
+
+proc getMethodName(m: jobject): string {.inline.} =
+    let m = Method.fromJObject(m)
+    result = m.getName()
+    m.free()
+#    m.setObj(nil)
+
+proc objToStr(o: jobject): string =
+    result = $o
+    theEnv.DeleteLocalRef(theEnv, o)
+
+template objToVal(typ: typedesc, valIdent: untyped, o: jobject): untyped =
+    let ob = typ.fromJObject(o)
+    let res = valIdent(ob)
+    ob.free()
+    #theEnv.DeleteLocalRef(theEnv, o)
+    res
+
+proc getArg(t: typedesc, args: jobjectArray, i: int): t {.inline.} =
+    let a = theEnv.GetObjectArrayElement(theEnv, args, i.jint)
+    when t is jobject: a
+    elif t is string: objToStr(a)
+    elif t is jint: objToVal(Number, intValue, a)
+    elif t is jfloat: objToVal(Number, floatValue, a)
+    elif t is jdouble: objToVal(Number, doubleValue, a)
+    elif t is jlong: objToVal(Number, longValue, a)
+    elif t is jshort: objToVal(Number, shortValue, a)
+    elif t is jbyte: objToVal(Number, byteValue, a)
+    elif t is jboolean: objToVal(Boolean, booleanValue, a)
+    elif t is JVMObject:
+        echo "FROM JOBJECT!!"
+        t.fromJObject(a)
+    else: {.error: "Dont know how to convert type".}
+
+proc toJObject(r: JVMObject): jobject =
+    result = r.get()
+    r.setObj(nil) # Release the reference
+
+proc toJObject(i: jint | jfloat | jdouble | jlong | jshort | jbyte): jobject = toWrapperType(i).toJObject()
+proc toJObject(i: jboolean): jobject = toWrapperType(i).toJObject()
+proc toJObject(i: string): jobject = newJVMObject(i).toJObject()
+
+proc makeCallForProc(p: NimNode): NimNode =
+    result = newCall(p.name)
+    result.add(ident("obj"))
+    for i in 2 ..< p.params.len:
+        result.add(newCall(bindSym "getArg", p.params[i][1], ident "args", newLit(i - 2)))
+    if p.params[0].kind != nnkEmpty:
+        result = newAssignment(ident("result"), newCall(bindSym "toJObject", result))
+
+proc makeDispatcherImpl(typ: NimNode, name: NimNode, body: NimNode): NimNode =
+    let methid = ident("meth")
+    result = newProc(name, [ident("jobject"),
+        newIdentDefs(ident("env"), ident("pointer")),
+        newIdentDefs(ident("obj"), typ),
+        newIdentDefs(ident("proxiedThis"), ident("jobject")),
+        newIdentDefs(methid, ident("jobject")),
+        newIdentDefs(ident("args"), ident("jobjectArray"))])
+    result.addPragma(ident("cdecl"))
+
+    result.body = body
+
+    let caseStmt = newNimNode(nnkCaseStmt).add(newCall(bindSym "getMethodName", methid))
+
+    for p in body:
+        caseStmt.add(newNimNode(nnkOfBranch).add(newLit($p.name), makeCallForProc(p)))
+
+    result.body.add(caseStmt)
+
+macro implementDispatcher*(typ: untyped, name: untyped, body: untyped): untyped =
+    result = makeDispatcherImpl(typ, name, body)

--- a/support/io/github/vegansk/jnim/NativeInvocationHandler.java
+++ b/support/io/github/vegansk/jnim/NativeInvocationHandler.java
@@ -1,0 +1,29 @@
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+public class NativeInvocationHandler implements InvocationHandler {
+    public static Object m(Class cl, long nimObjRef, long nimFuncPtr) {
+        NativeInvocationHandler handler = new NativeInvocationHandler();
+        handler.h = nimObjRef;
+        handler.fp = nimFuncPtr;
+        return Proxy.newProxyInstance(cl.getClassLoader(), new Class[] { cl }, handler);
+    }
+
+    public Object invoke(Object obj, Method m, Object[] args) throws Throwable {
+        return i(h, fp, obj, m, args);
+    }
+
+    protected void finalize() {
+        f(h);
+    }
+
+    public void d() {
+        h = 0;
+        fp = 0;
+    }
+
+    static native Object i(long nimObjRef, long nimFuncPtr, Object obj, Method m, Object[] args);
+    static native void f(long nimObjRef);
+    long h, fp;
+}

--- a/tests/java/ExportTestClass.java
+++ b/tests/java/ExportTestClass.java
@@ -1,0 +1,24 @@
+class ExportTestClass {
+    public interface OverridableInterface {
+        public void voidMethod();
+        public int intMethod();
+        public String stringMethod();
+        public String stringMethodWithArgs(String s, int i);
+    }
+
+    public void callVoidMethod(OverridableInterface c) {
+        c.voidMethod();
+    }
+
+    public int callIntMethod(OverridableInterface c) {
+        return c.intMethod();
+    }
+
+    public String callStringMethod(OverridableInterface c) {
+        return c.stringMethod();
+    }
+
+    public String callStringMethodWithArgs(OverridableInterface c, String s, int i) {
+        return c.stringMethodWithArgs(s, i);
+    }
+}

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -3,5 +3,6 @@ import test_jvm_finder
 #import test_jni_wrapper
 import test_jni_api
 import test_jni_generator
+import test_jni_export
 import test_java_lang
 import test_java_util

--- a/tests/test_jni_export.nim
+++ b/tests/test_jni_export.nim
@@ -1,0 +1,71 @@
+
+import private.jni_api,
+       private.jni_generator,
+       private.jni_export,
+       ./common,
+       unittest
+
+suite "jni_export":
+  setup:
+    if not isJNIThreadInitialized():
+      initJNIForTests()
+
+  test "Make proxy":
+    jclassDef ExportTestClass$OverridableInterface of JVMObject
+    jclass ExportTestClass of JVMObject:
+      proc new
+      proc callVoidMethod(r: OverridableInterface)
+
+    type MyObj = ref object of RootObj
+      a: int
+
+    var mr = MyObj.new()
+    mr.a = 1
+    proc handler(env: pointer, o: RootRef, proxiedThis, meth: jobject, args: jobjectArray): jobject {.cdecl.} =
+      let mr = cast[MyObj](o)
+      inc mr.a
+
+    let runnableClazz = OverridableInterface.getJVMClassForType()
+    for i in 0 .. 3:
+      let pr = makeProxy(runnableClazz.get, mr, handler)
+
+      let tr = ExportTestClass.new()
+      tr.callVoidMethod(OverridableInterface.fromJObject(pr))
+
+    check: mr.a == 5
+
+  test "Implement dispatcher":
+    jclassDef ExportTestClass$OverridableInterface of JVMObject
+    jclass ExportTestClass of JVMObject:
+        proc new
+        proc callVoidMethod(r: OverridableInterface)
+        proc callIntMethod(r: OverridableInterface): jint
+        proc callStringMethod(r: OverridableInterface): string
+        proc callStringMethodWithArgs(r: OverridableInterface, s: string, i: jint): string
+
+    type MyObj = ref object of RootObj
+        a: int
+
+    implementDispatcher(MyObj, MyObj_dispatcher):
+      proc voidMethod(self: MyObj) =
+        inc self.a
+
+      proc intMethod(self: MyObj): jint =
+        return 123
+
+      proc stringMethod(self: MyObj): string =
+        return "123"
+
+      proc stringMethodWithArgs(self: MyObj, s: string, i: jint): string =
+        return "123" & $i & s
+
+    let mr = MyObj.new()
+    mr.a = 5
+    let pr = makeProxy(OverridableInterface, mr, MyObj_dispatcher)
+    let tr = ExportTestClass.new()
+    tr.callVoidMethod(pr)
+    check: mr.a == 6
+
+    check: tr.callIntMethod(pr) == 123
+    check: tr.callStringMethod(pr) == "123"
+    check: tr.callStringMethodWithArgs(pr, "789", 456) == "123456789"


### PR DESCRIPTION
This allows "subclassing" java interfaces from within Nim code. The implementation is quite crude and thus not added yet to the "public" api, besides its somewhat dependent on #29. Polishing and docs will be done after #29 is resolved.

High-level usage is demonstrated in `test_jni_export.nim` test "Implement dispatcher".