### PR TITLE
Changed ownership model. Closes #29

### DIFF
--- a/jnim.nimble
+++ b/jnim.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.6"
+version       = "0.3.0"
 author        = "Anatoly Galiulin"
 description   = "Java bridge for Nim"
 license       = "MIT"

--- a/src/java/lang.nim
+++ b/src/java/lang.nim
@@ -177,7 +177,7 @@ jclass java.lang.Exception* of Throwable:
   proc new*(cause: Throwable)
 
 proc asJVM*(ex: JavaException): Throwable =
-  Throwable.fromJObject(ex.getJVMException.newRef)
+  Throwable.fromJObject(ex.getJVMException.get)
 
 proc getCurrentJVMException*: Throwable =
   ((ref JavaException)getCurrentException())[].asJVM


### PR DESCRIPTION
So here goes.
1. I decided to follow the principle that disposing local ref is kinda unsafe behavior and thus added a few procs that explicitly state this fact in their names: e.g. `newJVMObjectConsumingLocalRef` and `fromJObjectConsumingLocalRef`.
2. Old `newJVMObject` and `fromJVMObject` now never take ownership, they always create a new global ref.
3. I've moved `fromJObject` from autogenerated proc to a single generic proc for the sake of simplicity. `newJVMObject` is done via `fromJObject` to keep a single code path where global refs are created. As a slight benefit, finalizer is no longer generated for every wrapper type, but the single version is reused for all of them.
4. Version bumped to `0.3.0` to stress on some really minor backward incompatibility, which in 99% might not be even noticed.

Case when old code is affected:
User code relied on creating a lot of objects with `fromJVMObject` and `newJVMObject` so that they were deleted by Nim gc before returning to Java from native call. Such reliance was wrong anyway, but now since jnim JVM wrappers do not take ownership of the refs, the user might want to delete them manually (or use `newJVMObjectConsumingLocalRef` and `fromJObjectConsumingLocalRef`), especially if the number of such local references is not predictable until native returns to java.
