### PR TITLE
Find class override

### DIFF
--- a/src/private/jni_export.nim
+++ b/src/private/jni_export.nim
@@ -20,10 +20,10 @@ proc finalizeInvocationHandler(env: pointer, clazz: jclass, nimRef: jlong) {.cde
 
 proc getHandlerClass(): jclass =
     checkInit
-    result = theEnv.FindClass(theEnv, "io/github/vegansk/jnim/NativeInvocationHandler")
+    result = findClass(theEnv, "io/github/vegansk/jnim/NativeInvocationHandler")
     if result.pointer.isNil:
         theEnv.ExceptionClear(theEnv)
-        result = theEnv.FindClass(theEnv, "NativeInvocationHandler")
+        result = findClass(theEnv, "NativeInvocationHandler")
         if result.pointer.isNil:
             theEnv.ExceptionClear(theEnv)
             raise newException(Exception, "invalid jnim integration, NativeInvocationHandler not found")

--- a/support/io/github/vegansk/jnim/NativeInvocationHandler.java
+++ b/support/io/github/vegansk/jnim/NativeInvocationHandler.java
@@ -1,3 +1,4 @@
+package io.github.vegansk.jnim;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;


### PR DESCRIPTION
This is a hacky hook to allow customizing class loading. The problem it solves is popular when using android `NativeActivity` for example. The classes in the apk are not found by `theEnv.FindClass` if native stack doesn't contain some familiar Java symbols. Crazy. With this patch merged the following could be implemented:
```nim
proc smarterFindClass(env: JNIEnvPtr, name: cstring): jclass =
    result = env.FindClass(env, name)
    if cast[pointer](result) == nil:
        env.ExceptionClear(env)
        let activityClass = env.FindClass(env, "android/app/Activity")
        let getClassLoader = env.GetMethodID(env, activityClass, "getClassLoader", "()Ljava/lang/ClassLoader;")
        env.deleteLocalRef(activityClass)
        let cls = env.CallObjectMethod(env, getAndroidActivity(), getClassLoader)
        let classLoader = env.FindClass(env, "java/lang/ClassLoader")
        let findClass = env.GetMethodID(env, classLoader, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;")
        env.deleteLocalRef(classLoader)
        let strClassName = env.NewStringUTF(env, name)
        result = cast[jclass](env.CallObjectMethod(env, cls, findClass, strClassName))
        env.deleteLocalRef(strClassName)
        env.deleteLocalRef(cls)
findClassOverride = smarterFindClass
```