### PR TITLE
Fancy inheritance for jobject hierarchy

### DIFF
--- a/src/private/jni_api.nim
+++ b/src/private/jni_api.nim
@@ -102,14 +102,14 @@ proc findRunningVM() =
 template checkInit* =
   if theEnv.isNil: findRunningVM()
 
-template deleteLocalRef*(env: JNIEnvPtr, r: jclass | jobject) =
-  env.DeleteLocalRef(env, cast[jobject](r))
+template deleteLocalRef*(env: JNIEnvPtr, r: jobject) =
+  env.DeleteLocalRef(env, r)
 
-template deleteGlobalRef*(env: JNIEnvPtr, r: jclass | jobject) =
-  env.DeleteGlobalRef(env, cast[jobject](r))
+template deleteGlobalRef*(env: JNIEnvPtr, r: jobject) =
+  env.DeleteGlobalRef(env, r)
 
-template newGlobalRef*[T :jclass | jobject](env: JNIEnvPtr, r: T): T =
-  cast[T](theEnv.NewGlobalRef(theEnv, cast[jobject](r)))
+template newGlobalRef*[T : jobject](env: JNIEnvPtr, r: T): T =
+  cast[T](theEnv.NewGlobalRef(theEnv, r))
 
 ####################################################################################################
 # Types
@@ -703,7 +703,8 @@ template jarrayToSeqImpl[T](arr: jarray, res: var seq[T]) =
   let length = theEnv.GetArrayLength(theEnv, arr)
   res = newSeq[T](length.int)
   when T is JPrimitiveType:
-    getArrayRegion(arr, 0, length, addr(res[0]))
+    type TT = T
+    getArrayRegion(jtypedArray[TT](arr), 0, length, addr(res[0]))
   elif T is JVMObject:
     for i in 0..<res.len:
       res[i] = T.fromJObjectConsumingLocalRef(theEnv.GetObjectArrayElement(theEnv, arr.jobjectArray, i.jsize))

--- a/src/private/jni_export.nim
+++ b/src/private/jni_export.nim
@@ -68,9 +68,6 @@ proc getMethodName(m: jobject): string {.inline.} =
     result = m.getName()
     m.free()
 
-proc objToStr(o: jobject): string =
-    result = $o
-
 template objToVal(typ: typedesc, valIdent: untyped, o: jobject): untyped =
     let ob = typ.fromJObject(o)
     let res = valIdent(ob)
@@ -80,7 +77,7 @@ template objToVal(typ: typedesc, valIdent: untyped, o: jobject): untyped =
 proc getArg(t: typedesc, args: jobjectArray, i: int): t {.inline.} =
     let a = theEnv.GetObjectArrayElement(theEnv, args, i.jint)
     when t is jobject: a
-    elif t is string: objToStr(a)
+    elif t is string: $cast[jstring](a)
     elif t is jint: objToVal(Number, intValue, a)
     elif t is jfloat: objToVal(Number, floatValue, a)
     elif t is jdouble: objToVal(Number, doubleValue, a)

--- a/src/private/jni_wrapper.nim
+++ b/src/private/jni_wrapper.nim
@@ -57,22 +57,27 @@ type
   jfloat* = cfloat
   jdouble* = cdouble
   jboolean* = uint8
-  jclass* = distinct pointer
+
+  jobject_base {.inheritable, pure.} = object
+  jobject* = ptr jobject_base
+  jclass* = ptr object of jobject
   jmethodID* = pointer
-  jobject* = pointer
   jfieldID* = pointer
-  jstring* = jobject
-  jthrowable* = jobject
-  jarray* = jobject
-  jobjectArray* = jarray
-  jbooleanArray* = jarray
-  jbyteArray* = jarray
-  jcharArray* = jarray
-  jshortArray* = jarray
-  jintArray* = jarray
-  jlongArray* = jarray
-  jfloatArray* = jarray
-  jdoubleArray* = jarray
+  jstring* = ptr object of jobject
+  jthrowable* = ptr object of jobject
+
+  jarray* = ptr object of jobject
+  jtypedArray*[T] = ptr object of jarray
+
+  jobjectArray* = jtypedArray[jobject]
+  jbooleanArray* = jtypedArray[jboolean]
+  jbyteArray* = jtypedArray[jbyte]
+  jcharArray* = jtypedArray[jchar]
+  jshortArray* = jtypedArray[jshort]
+  jintArray* = jtypedArray[jint]
+  jlongArray* = jtypedArray[jlong]
+  jfloatArray* = jtypedArray[jfloat]
+  jdoubleArray* = jtypedArray[jdouble]
   jweak* = jobject
 
   jvalue* {.union.} = object
@@ -585,7 +590,8 @@ type
     jdouble |
     jboolean
 
-template valueType*(T: typedesc): typedesc =
+# The following templates are redundand because jarray types are generic.
+template valueType*(T: typedesc): typedesc {.deprecated.} =
   when T is jobjectArray:
     jobject
   elif T is jcharArray:
@@ -608,7 +614,7 @@ template valueType*(T: typedesc): typedesc =
     {.error: "Can't use type " & astToStr(T) & " with java's arrays".}
     discard
 
-template arrayType*(T: typedesc): typedesc =
+template arrayType*(T: typedesc): typedesc {.deprecated.} =
   when T is jobject:
     jobjectArray
   elif T is jchar:


### PR DESCRIPTION
This changes `jobject` and its subclasses hierarchy to be represented in Nim terms of inheritance. E.g. previously one could implicitly "convert" from jarray to jbyteArray, now he can't. Only vice-versa.

Note that this change might be breaking, if types were misused.