### PR TITLE
Fixed do notation parse error

### DIFF
--- a/jnim.nimble
+++ b/jnim.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.0"
+version       = "0.3.1"
 author        = "Anatoly Galiulin"
 description   = "Java bridge for Nim"
 license       = "MIT"


### PR DESCRIPTION
Nim has recently changed do-notation parsing rules. More info: https://github.com/nim-lang/Nim/issues/5733.
Also bumped jnim version.