### PR TITLE
Map nil jobjects to nil JVMObjects

### DIFF
--- a/jnim.nimble
+++ b/jnim.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.1"
+version       = "0.3.2"
 author        = "Anatoly Galiulin"
 description   = "Java bridge for Nim"
 license       = "MIT"


### PR DESCRIPTION
* Fixed nil jobject return values being wrapped into a "valid" `JVMObject`. Return nil instead.
* Return nil in `*ConsumingLocalRef` functions when the ref is nil.
* Forbid passing nil to `fromJObject` with `assert`
* Bump version
* Cosmetics: removed `expr` and `immediate`.