### PR TITLE
Dont crash on nil strings and objects

### DIFF
--- a/jnim.nimble
+++ b/jnim.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.3"
+version       = "0.3.4"
 author        = "Anatoly Galiulin"
 description   = "Java bridge for Nim"
 license       = "MIT"

--- a/src/private/jni_api.nim
+++ b/src/private/jni_api.nim
@@ -298,7 +298,8 @@ proc newJVMObjectConsumingLocalRef*(o: jobject): JVMObject =
 proc create*(t: typedesc[JVMObject], o: jobject): JVMObject = newJVMObject(o)
 
 proc newJVMObject*(s: string): JVMObject =
-  (callVM theEnv.NewStringUTF(theEnv, s)).newJVMObjectConsumingLocalRef
+  if not s.isNil:
+    result = (callVM theEnv.NewStringUTF(theEnv, s)).newJVMObjectConsumingLocalRef
 
 proc get*(o: JVMObject): jobject =
   o.obj
@@ -308,7 +309,8 @@ proc setObj*(o: JVMObject, obj: jobject) =
   o.obj = obj
 
 proc toJValue*(o: JVMObject): jvalue =
-  o.get.toJValue
+  if not o.isNil:
+    result = o.get.toJValue
 
 proc getJVMClass*(o: JVMObject): JVMClass =
   assert(o.get != nil)
@@ -689,7 +691,7 @@ genMethod(jboolean, Boolean)
 proc getJVMException*(ex: JavaException): JVMObject =
   ex.ex
 
-proc toJVMObject*(s: string): JVMObject =
+proc toJVMObject*(s: string): JVMObject {.inline.} =
   newJVMObject(s)
 
 type JPrimitiveType = jint | jfloat | jboolean | jdouble | jshort | jlong | jchar | jbyte

--- a/tests/test_jni_api.nim
+++ b/tests/test_jni_api.nim
@@ -180,4 +180,6 @@ suite "jni_api":
   test "API - jstring $":
     check: $(theEnv.NewStringUTF(theEnv, "test")) == "test"
 
-
+  test "API - nil strings are nil JVMObjects":
+    var nilString: string
+    check: newJVMObject(nilString) == nil


### PR DESCRIPTION
This fixes a crash, when trying to pass a nil string or nil JVMObject to generated apis.