### PR TITLE
jexport: allow redefining JnimPackageName with -d

### DIFF
--- a/jnim/private/jni_export.nim
+++ b/jnim/private/jni_export.nim
@@ -6,7 +6,7 @@ type MethodDescr = object
   argTypes: seq[string]
 
 const
-  JnimPackageName = "io.github.yglukhov.jnim"
+  JnimPackageName {.strdefine.} = "io.github.yglukhov.jnim"
   FinalizerName = "_0"
   PointerFieldName = "_1"
   InitializerName = "_2"


### PR DESCRIPTION
This allows running e.g. `nim c -d:JnimPackageName=com.akavel.foobar ...` to change the Java package name from hardcoded `io.github.yglukhov.jnim` to something custom.