### PR TITLE
jexport: implement -d:jnimGenDex

### DIFF
--- a/jnim.nim
+++ b/jnim.nim
@@ -1,4 +1,4 @@
-import jnim/private / [ jvm_finder, jni_wrapper, jni_api, jni_generator ]
+import jnim/private / [ jvm_finder, jni_wrapper, jni_api, jni_generator, jni_export ]
 
-export jvm_finder, jni_wrapper, jni_api, jni_generator
+export jvm_finder, jni_wrapper, jni_api, jni_generator, jni_export
 


### PR DESCRIPTION
This change makes it possible to use `jexport` together with `jnimDexWrite` to
emit .dex files. The `jnimDexWrite` proc builds a .nim file, which can then be
compiled using package dali to generate a .dex file.

For an example project using this approach, see:
https://github.com/akavel/hellomello/blob/9d1a77cef872edcb9fcf6771e7ccea1621e59978/hellomello.nimble#L24-L25

Currently, the intermediate step of generating a .nim file is required, as
Nim's compile-time has a lot of limitations. In this particular case, see e.g.:
- https://github.com/nim-lang/Nim/issues/14339
- https://github.com/nim-lang/Nim/issues/14340

Fixes #56.